### PR TITLE
Makefileでpytest実行できるよう調整

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ ps:
 	docker-compose ps -a
 
 test:
-	docker-compose run --rm app pytest tests
+	docker-compose exec app poetry run pytest


### PR DESCRIPTION
## 実装概要
以下実装。
- makeコマンドでpytestの実行コマンドを追加

## 背景
- #14 
- `poetry run`を接頭におく必要があった

## 次回の実装内容
- テスト環境リファクタする
