### PR TITLE
linter（flake8）の導入

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 90
+ignore = E203, E266, E501, W503
+exclude = .git, .github, __pycache__, .venv, .dockerenv, 

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ test:
 
 fmt:
 	docker-compose exec app poetry run black src tests
+
+lint:
+	docker-compose exec app poetry run flake8

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,6 +147,22 @@ typing-extensions = ">=4.8.0"
 all = ["email-validator (>=2.0.0)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "flake8"
+version = "6.1.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
+    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.11.0,<2.12.0"
+pyflakes = ">=3.1.0,<3.2.0"
+
+[[package]]
 name = "greenlet"
 version = "3.0.1"
 description = "Lightweight in-process concurrent programming"
@@ -431,6 +447,17 @@ files = [
 ]
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -513,6 +540,17 @@ files = [
     {file = "psycopg2-2.9.9-cp39-cp39-win32.whl", hash = "sha256:c92811b2d4c9b6ea0285942b2e7cac98a59e166d59c588fe5cfe1eda58e72d59"},
     {file = "psycopg2-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:de80739447af31525feddeb8effd640782cf5998e1a4e9192ebdf829717e3913"},
     {file = "psycopg2-2.9.9.tar.gz", hash = "sha256:d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156"},
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.11.1"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
+    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
 ]
 
 [[package]]
@@ -646,6 +684,17 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pyflakes"
+version = "3.1.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
+    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
+]
 
 [[package]]
 name = "pytest"
@@ -1134,4 +1183,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c47a1aa192ca35a26e999e3940c5792ebc9d6604d8527935262a7d4194ed1e2c"
+content-hash = "1b14fb6841a3656fdd13429f766206220eeef61785b2ce3d00b68cda7f3bc6f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ black = "^23.11.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
+flake8 = "^6.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/databases/migration/versions/cdaa1c373ee5_create_items_table.py
+++ b/src/databases/migration/versions/cdaa1c373ee5_create_items_table.py
@@ -1,7 +1,7 @@
 """create items table
 
 Revision ID: cdaa1c373ee5
-Revises: 
+Revises:
 Create Date: 2023-11-13 22:57:08.720703
 
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,6 @@
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, scoped_session
-from sqlalchemy_utils import database_exists, drop_database
-from src.db import Base
-
-"""使用していないが、後で確認する"""
+from sqlalchemy.orm import sessionmaker
 
 
 @pytest.fixture(scope="session")

--- a/tests/databases/databases.py
+++ b/tests/databases/databases.py
@@ -1,5 +1,3 @@
-from src.db import session_factory
-from src.main import app
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 


### PR DESCRIPTION
## 実装概要
以下実装。
- flake8のインストール
- `.flake8`によるlintの設定
- Makefileのコマンド追加
- lintの指示による修正

## 背景
- #9 

## 次回の実装内容
- テスト環境のリファクタ
