### PR TITLE
depends_onでテストDBコンテナを指定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     tty: true
     stdin_open: true
     depends_on:
+      - db-test
       - db
 
   db:


### PR DESCRIPTION
## 実装概要
以下実装。
- docker-compose.ymlの`depends_on`でdb-testを明示的に指定

## 背景
何かあれば。
- #29 

## 次回の実装内容
- READMEの更新
